### PR TITLE
Fixed an error on windows and added better support for use within a local package

### DIFF
--- a/plugin/bootstrap3.js
+++ b/plugin/bootstrap3.js
@@ -77,7 +77,8 @@ class BootstrapCompiler {
 
 
       // Get the settings file dir
-      const settingsPathDir = path.dirname(path.join('.', settingsFile.getDisplayPath()))
+      const settingsFilePath = path.join('.', resolveFilePath(`{${settingsFile.getPackageName()||''}}/${settingsFile.getPathInPackage()}`));
+      const settingsPathDir = path.dirname(settingsFilePath);
 
 
       // Get the settings data
@@ -130,7 +131,7 @@ class BootstrapCompiler {
         src = src.replace(/\n\s*\/\*LESS_MODULES\*\//, '\n' + lessJson)
                  .replace(/\n\s*\/\*JS_MODULES\*\//, '\n' + jsJson)
 
-        fs.writeFileSync(path.join('.', settingsFile.getDisplayPath()), src)
+        fs.writeFileSync(settingsFilePath, src)
 
         settings = JSON.parse(src)
       }
@@ -281,4 +282,23 @@ class BootstrapCompiler {
       })
     }
   }
+}
+
+
+function resolveFilePath(filePath) {
+	const match = filePath.match(/{(.*)}\/(.*)$/);
+	if (!match)
+		return filePath;
+
+	if (match[1] === '') return match[2];
+
+	var paths = [];
+
+	paths[1] = paths[0] = `packages/${match[1].replace(':', '_')}/${match[2]}`;
+	if (!fs.existsSync(paths[0]))
+		paths[2] = paths[0] = 'packages/' + match[1].replace(/.*:/, '') + '/' + match[2];
+	if (!fs.existsSync(paths[0]))
+		throw new Error(`Path not exist: ${filePath}\nTested path 1: ${paths[1]}\nTest path 2: ${paths[2]}`);
+
+	return paths[0];
 }

--- a/plugin/bootstrap3.js
+++ b/plugin/bootstrap3.js
@@ -57,7 +57,7 @@ class BootstrapCompiler {
 
     // Loop through and find the settings file
     for (let file of filesFound) {
-      let fn = path.basename(file.getDisplayPath())
+      let fn = path.basename(path.join('.', file.getDisplayPath()))
       if (fn === bootstrapSettings) {
         if (settingsFile)
           throw new Error('You cannot have more than one ' + bootstrapSettings + ' in your Meteor project.')


### PR DESCRIPTION
b6c8c51:
I develop primarily on Windows and this package had an error (all of the path functions freak out about a leading slash, which was provided by settingsFile.getDisplayPath()), so I fixed it. 

331720c:
I'm using the package-based structure (basically all of my app files are within packages). I needed to include your package from one of my packages so I could easily make sure bootstrap's CSS loaded before my CSS, but settingsFile.getDisplayPath() doesn't return the default path that is created by _meteor create --package author:package_.

The default path for a new package - at least on Windows - is _packages/package_, but settingsFile.getDisplayPath() returns _packages/author_package_.

To resolve this issue when loading a bootstrap-settings.json file from a package, I've adjusted the code to try _packages/author_package_ first; if it can't find the bootstrap-settings.json there, it then tries _packages/package_.
